### PR TITLE
Test on Threadripper 2990WX and fix SMT

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,5 +11,6 @@ gcc -o ryzen ryzen.c -lm
 Needs access to /dev/cpu/CPUNO/msr files. So may need root rights
 
 ## Tested on: ##
+ * AMD Ryzen Threadripper 2990WX
  * AMD Ryzen Threadripper 1950x
  * AMD Epyc 7501

--- a/ryzen.c
+++ b/ryzen.c
@@ -137,7 +137,7 @@ static int rapl_msr_amd_core() {
 	int *fd = (int*)malloc(sizeof(int)*total_cores/2);
 	
 	for (int i = 0; i < total_cores/2; i++) {
-		fd[i] = open_msr(i);
+		fd[i] = open_msr(i*2);
 	}
 	
 	int core_energy_units = read_msr(fd[0], AMD_MSR_PWR_UNIT);


### PR DESCRIPTION
On almost every Linux kernel, core i and i+1 are the two threads of a single physical core. Power consumption statistics can therefore be obtained by reading the MSRs or cores 0, 2, 4, ..., 60, 62.

This pull request makes rapl report proper power consumption on my machine. By the way, this tool is absolutely amazing! I have been looking for something like this for a year and a half!